### PR TITLE
Use own ignition-fork to get sources from it instead of bitbucket

### DIFF
--- a/ogre2/portfile.cmake
+++ b/ogre2/portfile.cmake
@@ -3,11 +3,14 @@ include(vcpkg_common_functions)
 # Development only with release
 # set(VCPKG_BUILD_TYPE release)
 
-vcpkg_from_bitbucket(
+# Originally in bitbucket at
+# REPO sinbad/ogre
+# REF 06a386fa64e7
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO sinbad/ogre
-    REF 06a386fa64e7
-    SHA512 e91e7dd67db921b46d3705334b05bbbe74721893807b6a5c83a96d54fe97debbbc307999afaafd606ceed6f2ab9f5d0117ae64b802ac03b077771ee3b09ce458
+    REPO osrf/vcpkg-ports
+    REF 946771661f34edf28ca82c0ef7a6564ed7b52f3d
+    SHA512 23cb3b9f6e86f29d67f5e6cacf65ac5878f34a1e78c559378096a8e137e83236502ddec40881aa89d238aaad44b8e992751a086ac13ae6d0077ae816bf196863
 )
 
 message(STATUS "SOURCE PATH: ${SOURCE_PATH}")

--- a/ogre2/portfile.cmake
+++ b/ogre2/portfile.cmake
@@ -8,7 +8,7 @@ include(vcpkg_common_functions)
 # REF 06a386fa64e7
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO osrf/vcpkg-ports
+    REPO osrf/ogre-2.1-release
     REF 946771661f34edf28ca82c0ef7a6564ed7b52f3d
     SHA512 23cb3b9f6e86f29d67f5e6cacf65ac5878f34a1e78c559378096a8e137e83236502ddec40881aa89d238aaad44b8e992751a086ac13ae6d0077ae816bf196863
 )


### PR DESCRIPTION
Bitbucket sources for ogre are dead. This PR replaces sources there by the ones present in our own fork `osrf/ogre-2.1-release`.

The commit used in Bitbucket 06a386fa64e7 should be the one present in https://github.com/ignition-forks/ogre-2.1-release/commit/946771661f34edf28ca82c0ef7a6564ed7b52f3d. No real ogre code change 