### PR TITLE
Add icu version bump on 2020.01 snapshot to workaround problems with incosistent hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Packages in this repository
+
+## Ogre2
+
+Description: ogre2 port maintained by Open Robotics. Sources come from
+https://github.com/osrf/ogre-2.1-release
+Status: permanent
+
+## icu
+
+Description: cloen of vcpkg official 2020.01 snapshot with a fix for bug
+https://github.com/microsoft/vcpkg/issues/14733
+Status: temporary. Should be removed when upgrading to a new snapshot

--- a/icu/CONTROL
+++ b/icu/CONTROL
@@ -1,0 +1,4 @@
+Source: icu
+Version: 61.1-9
+Homepage: http://icu-project.org/apiref/icu4c/
+Description: Mature and widely used Unicode and localization library.

--- a/icu/disable-escapestr-tool.patch
+++ b/icu/disable-escapestr-tool.patch
@@ -1,0 +1,17 @@
+diff --git a/source/tools/Makefile.in b/source/tools/Makefile.in
+index c3f81d6..dc41af3 100644
+--- a/source/tools/Makefile.in
++++ b/source/tools/Makefile.in
+@@ -19,9 +19,9 @@ SUBDIRS = toolutil ctestfw makeconv genrb genbrk \
+ gencnval gensprep icuinfo genccode gencmn icupkg pkgdata \
+ gentest gennorm2 gencfu gendict
+ 
+-ifneq (@platform_make_fragment_name@,mh-cygwin-msvc)
+-SUBDIRS += escapesrc
+-endif
++#ifneq (@platform_make_fragment_name@,mh-cygwin-msvc)
++#SUBDIRS += escapesrc
++#endif
+ 
+ ## List of phony targets
+ .PHONY : all all-local all-recursive install install-local	\

--- a/icu/fix_parallel_build_on_windows.patch
+++ b/icu/fix_parallel_build_on_windows.patch
@@ -1,0 +1,13 @@
+diff --git a/source/data/Makefile.in b/source/data/Makefile.in
+index 1140b69..936ef81 100644
+--- a/source/data/Makefile.in
++++ b/source/data/Makefile.in
+@@ -514,7 +514,7 @@ build-dir:
+ # The | is an order-only prerequisite. This helps when the -j option is used,
+ # and we don't want the files to be built before the directories are built.
+ ifneq ($(filter order-only,$(.FEATURES)),)
+-$(ALL_FILES) $(ALL_INDEX_SRC_FILES): | build-dir
++$(ALL_FILES) $(ALL_INDEX_SRC_FILES) $(SO_VERSION_DATA): | build-dir
+ endif
+ 
+ # Now, sections for building each kind of data.

--- a/icu/portfile.cmake
+++ b/icu/portfile.cmake
@@ -1,0 +1,224 @@
+if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+    message(FATAL_ERROR "Error: UWP builds are currently not supported.")
+endif()
+
+include(vcpkg_common_functions)
+
+set(VERSION 61.1)
+set(VERSION2 61_1)
+set(ICU_VERSION_MAJOR 61)
+
+vcpkg_download_distfile(
+    ARCHIVE
+    URLS "http://download.icu-project.org/files/icu4c/${VERSION}/icu4c-${VERSION2}-src.tgz"
+    FILENAME "icu4c-${VERSION2}-src.tgz"
+    SHA512 4c37691246db802e4bae0c8c5f6ac1dac64c5753b607e539c5c1c36e361fcd9dd81bd1d3b5416c2960153b83700ccdb356412847d0506ab7782ae626ac0ffb94
+)
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/disable-escapestr-tool.patch
+        ${CMAKE_CURRENT_LIST_DIR}/remove-MD-from-configure.patch
+        ${CMAKE_CURRENT_LIST_DIR}/fix_parallel_build_on_windows.patch
+)
+
+set(CONFIGURE_OPTIONS "--disable-samples --disable-tests")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(CONFIGURE_OPTIONS "${CONFIGURE_OPTIONS} --disable-static --enable-shared")
+else()
+    set(CONFIGURE_OPTIONS "${CONFIGURE_OPTIONS} --enable-static --disable-shared")
+endif()
+
+set(CONFIGURE_OPTIONS_RELASE "--disable-debug --enable-release --prefix=${CURRENT_PACKAGES_DIR}")
+set(CONFIGURE_OPTIONS_DEBUG  "--enable-debug --disable-release --prefix=${CURRENT_PACKAGES_DIR}/debug")
+
+if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    set(BASH bash)
+    set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -fPIC")
+    set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -fPIC")
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        # Configure release
+        message(STATUS "Configuring ${TARGET_TRIPLET}-rel")
+        file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel)
+        file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel)
+        set(ENV{CFLAGS} "-O2 ${VCPKG_C_FLAGS} ${VCPKG_C_FLAGS_RELEASE}")
+        set(ENV{CXXFLAGS} "-O2 ${VCPKG_CXX_FLAGS} ${VCPKG_CXX_FLAGS_RELEASE}")
+        vcpkg_execute_required_process(
+            COMMAND ${BASH} --noprofile --norc -c
+                "${SOURCE_PATH}/source/runConfigureICU Linux ${CONFIGURE_OPTIONS} ${CONFIGURE_OPTIONS_RELASE}"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
+            LOGNAME "configure-${TARGET_TRIPLET}-rel")
+        message(STATUS "Configuring ${TARGET_TRIPLET}-rel done")
+    endif()
+
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        # Configure debug
+        message(STATUS "Configuring ${TARGET_TRIPLET}-dbg")
+        file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)
+        file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)
+        set(ENV{CFLAGS} "-O0 -g ${VCPKG_C_FLAGS} ${VCPKG_C_FLAGS_DEBUG}")
+        set(ENV{CXXFLAGS} "-O0 -g ${VCPKG_CXX_FLAGS} ${VCPKG_CXX_FLAGS_DEBUG}")
+        vcpkg_execute_required_process(
+            COMMAND ${BASH} --noprofile --norc -c
+                "${SOURCE_PATH}/source/runConfigureICU Linux ${CONFIGURE_OPTIONS} ${CONFIGURE_OPTIONS_DEBUG}"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
+            LOGNAME "configure-${TARGET_TRIPLET}-dbg")
+        message(STATUS "Configuring ${TARGET_TRIPLET}-dbg done")
+    endif()
+
+else()
+
+    set(CONFIGURE_OPTIONS "${CONFIGURE_OPTIONS} --host=i686-pc-mingw32")
+
+    # Acquire tools
+    vcpkg_acquire_msys(MSYS_ROOT PACKAGES make automake1.15)
+
+    # Insert msys into the path between the compiler toolset and windows system32. This prevents masking of "link.exe" but DOES mask "find.exe".
+    string(REPLACE ";$ENV{SystemRoot}\\system32;" ";${MSYS_ROOT}/usr/bin;$ENV{SystemRoot}\\system32;" NEWPATH "$ENV{PATH}")
+    string(REPLACE ";$ENV{SystemRoot}\\System32;" ";${MSYS_ROOT}/usr/bin;$ENV{SystemRoot}\\System32;" NEWPATH "${NEWPATH}")
+    set(ENV{PATH} "${NEWPATH}")
+    set(BASH ${MSYS_ROOT}/usr/bin/bash.exe)
+
+    set(AUTOMAKE_DIR ${MSYS_ROOT}/usr/share/automake-1.15)
+    file(COPY ${AUTOMAKE_DIR}/config.guess ${AUTOMAKE_DIR}/config.sub DESTINATION ${SOURCE_PATH}/source)
+
+    if(VCPKG_CRT_LINKAGE STREQUAL static)
+        set(ICU_RUNTIME "-MT")
+    else()
+        set(ICU_RUNTIME "-MD")
+    endif()
+
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        # Configure release
+        message(STATUS "Configuring ${TARGET_TRIPLET}-rel")
+        file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel)
+        file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel)
+        set(ENV{CFLAGS} "${ICU_RUNTIME} -O2 -Oi -Zi -FS ${VCPKG_C_FLAGS} ${VCPKG_C_FLAGS_RELEASE}")
+        set(ENV{CXXFLAGS} "${ICU_RUNTIME} -O2 -Oi -Zi -FS ${VCPKG_CXX_FLAGS} ${VCPKG_CXX_FLAGS_RELEASE}")
+        set(ENV{LDFLAGS} "-DEBUG -INCREMENTAL:NO -OPT:REF -OPT:ICF")
+        vcpkg_execute_required_process(
+            COMMAND ${BASH} --noprofile --norc -c
+                "${SOURCE_PATH}/source/runConfigureICU MSYS/MSVC ${CONFIGURE_OPTIONS} ${CONFIGURE_OPTIONS_RELASE}"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
+            LOGNAME "configure-${TARGET_TRIPLET}-rel")
+        message(STATUS "Configuring ${TARGET_TRIPLET}-rel done")
+    endif()
+
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        # Configure debug
+        message(STATUS "Configuring ${TARGET_TRIPLET}-dbg")
+        file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)
+        file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)
+        set(ENV{CFLAGS} "${ICU_RUNTIME}d -Od -Zi -FS -RTC1 ${VCPKG_C_FLAGS} ${VCPKG_C_FLAGS_DEBUG}")
+        set(ENV{CXXFLAGS} "${ICU_RUNTIME}d -Od -Zi -FS -RTC1 ${VCPKG_CXX_FLAGS} ${VCPKG_CXX_FLAGS_DEBUG}")
+        set(ENV{LDFLAGS} "-DEBUG")
+        vcpkg_execute_required_process(
+            COMMAND ${BASH} --noprofile --norc -c
+                "${SOURCE_PATH}/source/runConfigureICU MSYS/MSVC ${CONFIGURE_OPTIONS} ${CONFIGURE_OPTIONS_DEBUG}"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
+            LOGNAME "configure-${TARGET_TRIPLET}-dbg")
+        message(STATUS "Configuring ${TARGET_TRIPLET}-dbg done")
+    endif()
+endif()
+
+unset(ENV{CFLAGS})
+unset(ENV{CXXFLAGS})
+unset(ENV{LDFLAGS})
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    # Build release
+    message(STATUS "Package ${TARGET_TRIPLET}-rel")
+    vcpkg_execute_build_process(
+        COMMAND ${BASH} --noprofile --norc -c "make -j ${VCPKG_CONCURRENCY}"
+        NO_PARALLEL_COMMAND ${BASH} --noprofile --norc -c "make"
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
+        LOGNAME "make-build-${TARGET_TRIPLET}-rel")
+
+    vcpkg_execute_build_process(
+        COMMAND ${BASH} --noprofile --norc -c "make install"
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
+        LOGNAME "make-install-${TARGET_TRIPLET}-rel")
+    message(STATUS "Package ${TARGET_TRIPLET}-rel done")
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    # Build debug
+    message(STATUS "Package ${TARGET_TRIPLET}-dbg")
+    vcpkg_execute_build_process(
+        COMMAND ${BASH} --noprofile --norc -c "make -j ${VCPKG_CONCURRENCY}"
+        NO_PARALLEL_COMMAND ${BASH} --noprofile --norc -c "make"
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
+        LOGNAME "make-build-${TARGET_TRIPLET}-dbg")
+
+    vcpkg_execute_build_process(
+        COMMAND ${BASH} --noprofile --norc -c "make install"
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
+        LOGNAME "make-install-${TARGET_TRIPLET}-dbg")
+    message(STATUS "Package ${TARGET_TRIPLET}-dbg done")
+endif()
+
+file(REMOVE_RECURSE
+    ${CURRENT_PACKAGES_DIR}/bin
+    ${CURRENT_PACKAGES_DIR}/debug/bin
+    ${CURRENT_PACKAGES_DIR}/debug/include
+    ${CURRENT_PACKAGES_DIR}/share
+    ${CURRENT_PACKAGES_DIR}/debug/share
+    ${CURRENT_PACKAGES_DIR}/lib/pkgconfig
+    ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig
+    ${CURRENT_PACKAGES_DIR}/lib/icu
+    ${CURRENT_PACKAGES_DIR}/debug/lib/icud)
+
+file(GLOB TEST_LIBS
+    ${CURRENT_PACKAGES_DIR}/lib/*test*
+    ${CURRENT_PACKAGES_DIR}/debug/lib/*test*)
+file(REMOVE ${TEST_LIBS})
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    # copy icu dlls from lib to bin
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        file(GLOB RELEASE_DLLS ${CURRENT_PACKAGES_DIR}/lib/icu*${ICU_VERSION_MAJOR}.dll)
+        file(COPY ${RELEASE_DLLS} DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+    endif()
+
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        file(GLOB DEBUG_DLLS ${CURRENT_PACKAGES_DIR}/debug/lib/icu*d${ICU_VERSION_MAJOR}.dll)
+        file(COPY ${DEBUG_DLLS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+    endif()
+else()
+    if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+        # rename static libraries to match import libs
+        # see https://gitlab.kitware.com/cmake/cmake/issues/16617
+        foreach(MODULE dt in io tu uc)
+            if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+                file(RENAME ${CURRENT_PACKAGES_DIR}/lib/sicu${MODULE}.lib ${CURRENT_PACKAGES_DIR}/lib/icu${MODULE}.lib)
+            endif()
+
+            if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+                file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/sicu${MODULE}d.lib ${CURRENT_PACKAGES_DIR}/debug/lib/icu${MODULE}d.lib)
+            endif()
+        endforeach()
+    endif()
+
+    # force U_STATIC_IMPLEMENTATION macro
+    foreach(HEADER utypes.h utf_old.h platform.h)
+        file(READ ${CURRENT_PACKAGES_DIR}/include/unicode/${HEADER} HEADER_CONTENTS)
+        string(REPLACE "defined(U_STATIC_IMPLEMENTATION)" "1" HEADER_CONTENTS "${HEADER_CONTENTS}")
+        file(WRITE ${CURRENT_PACKAGES_DIR}/include/unicode/${HEADER} "${HEADER_CONTENTS}")
+    endforeach()
+endif()
+
+# remove any remaining dlls in /lib
+file(GLOB DUMMY_DLLS ${CURRENT_PACKAGES_DIR}/lib/*.dll ${CURRENT_PACKAGES_DIR}/debug/lib/*.dll)
+if(DUMMY_DLLS)
+    file(REMOVE ${DUMMY_DLLS})
+endif()
+
+# Generates warnings about missing pdbs for icudt.dll
+# This is expected because ICU database contains no executable code
+vcpkg_copy_pdbs()
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/icu)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/icu/LICENSE ${CURRENT_PACKAGES_DIR}/share/icu/copyright)

--- a/icu/portfile.cmake
+++ b/icu/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS "http://download.icu-project.org/files/icu4c/${VERSION}/icu4c-${VERSION2}-src.tgz"
     FILENAME "icu4c-${VERSION2}-src.tgz"
-    SHA512 4c37691246db802e4bae0c8c5f6ac1dac64c5753b607e539c5c1c36e361fcd9dd81bd1d3b5416c2960153b83700ccdb356412847d0506ab7782ae626ac0ffb94
+    SHA512 300c2fb3b5d490b5eef836a14d73dd0036feda18fee3f1716076adf78b579b35d72a0d23336c110055448d31c5580517da3846f8c61a3bfc31544fe749b98089
 )
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/icu/portfile.cmake
+++ b/icu/portfile.cmake
@@ -4,15 +4,17 @@ endif()
 
 include(vcpkg_common_functions)
 
-set(VERSION 61.1)
-set(VERSION2 61_1)
 set(ICU_VERSION_MAJOR 61)
+set(ICU_VERSION_MINOR 1)
+set(VERSION "${ICU_VERSION_MAJOR}.${ICU_VERSION_MINOR}")
+set(VERSION2 "${ICU_VERSION_MAJOR}_${ICU_VERSION_MINOR}")
+set(VERSION3 "${ICU_VERSION_MAJOR}-${ICU_VERSION_MINOR}")
 
 vcpkg_download_distfile(
     ARCHIVE
-    URLS "http://download.icu-project.org/files/icu4c/${VERSION}/icu4c-${VERSION2}-src.tgz"
+    URLS "https://github.com/unicode-org/icu/releases/download/release-${VERSION3}/icu4c-${VERSION2}-src.tgz"
     FILENAME "icu4c-${VERSION2}-src.tgz"
-    SHA512 300c2fb3b5d490b5eef836a14d73dd0036feda18fee3f1716076adf78b579b35d72a0d23336c110055448d31c5580517da3846f8c61a3bfc31544fe749b98089
+    SHA512 4c37691246db802e4bae0c8c5f6ac1dac64c5753b607e539c5c1c36e361fcd9dd81bd1d3b5416c2960153b83700ccdb356412847d0506ab7782ae626ac0ffb94
 )
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/icu/remove-MD-from-configure.patch
+++ b/icu/remove-MD-from-configure.patch
@@ -1,0 +1,18 @@
+diff -urN a/source/runConfigureICU b/source/runConfigureICU
+--- a/source/runConfigureICU	2018-03-26 21:38:44.000000000 +0800
++++ b/source/runConfigureICU	2018-08-26 09:04:53.197454400 +0800
+@@ -322,10 +322,10 @@
+         THE_COMP="Microsoft Visual C++"
+         CC=cl; export CC
+         CXX=cl; export CXX
+-        RELEASE_CFLAGS='-Gy -MD'
+-        RELEASE_CXXFLAGS='-Gy -MD'
+-        DEBUG_CFLAGS='-Zi -MDd'
+-        DEBUG_CXXFLAGS='-Zi -MDd'
++        RELEASE_CFLAGS='-Gy'
++        RELEASE_CXXFLAGS='-Gy'
++        DEBUG_CFLAGS='-Zi'
++        DEBUG_CXXFLAGS='-Zi'
+         DEBUG_LDFLAGS='-DEBUG'
+         ;;
+     *BSD)


### PR DESCRIPTION
Backport URL from master branch while keeping the same version than in 2020.01 tag.