### PR TITLE
Added dartsim fork to include MSVC 2022 compilation patch

### DIFF
--- a/dartsim/disable_unit_tests_examples_and_tutorials.patch
+++ b/dartsim/disable_unit_tests_examples_and_tutorials.patch
@@ -1,0 +1,13 @@
+﻿diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9940065eb8..b25fa4919a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -298,7 +298,7 @@ add_subdirectory(dart)
+ 
+ set(DART_IN_SOURCE_BUILD TRUE)
+ 
+-if(TARGET dart)
++if(false)
+ 
+   # Add a "tests" target to build unit tests.
+   enable_testing()

--- a/dartsim/fix_msvc2022_compilation.patch
+++ b/dartsim/fix_msvc2022_compilation.patch
@@ -1,0 +1,27 @@
+Title: Fix compilation with MSVC 2022
+Source: Michael Carroll <mjcarroll@intrinsic.ai>
+Description: Patch type to make MSVC2022 to be able to compile
+
+---
+diff --git a/dart/common/detail/Signal.hpp b/dart/common/detail/Signal.hpp
+index b7a6744d8ed1..844952e27bdd 100644
+--- a/dart/common/detail/Signal.hpp
++++ b/dart/common/detail/Signal.hpp
+@@ -84,7 +84,7 @@ void Signal<_Res(_ArgTypes...), Combiner>::disconnect(
+ //==============================================================================
+ template <typename _Res, typename... _ArgTypes, template <class> class Combiner>
+ void Signal<_Res(_ArgTypes...), Combiner>::disconnect(
+-    const std::shared_ptr<Signal::ConnectionBodyType>& connectionBody)
++    const std::shared_ptr<ConnectionBodyType>& connectionBody)
+ {
+   mConnectionBodies.erase(connectionBody);
+ }
+@@ -179,7 +179,7 @@ void Signal<void(_ArgTypes...)>::disconnect(const Connection& connection) const
+ //==============================================================================
+ template <typename... _ArgTypes>
+ void Signal<void(_ArgTypes...)>::disconnect(
+-    const std::shared_ptr<Signal::ConnectionBodyType>& connectionBody)
++    const std::shared_ptr<ConnectionBodyType>& connectionBody)
+ {
+   mConnectionBodies.erase(connectionBody);
+ }

--- a/dartsim/portfile.cmake
+++ b/dartsim/portfile.cmake
@@ -1,0 +1,45 @@
+# Shared library support is broken upstream (https://github.com/dartsim/dart/issues/1005#issuecomment-375406260)
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dartsim/dart
+    REF v6.11.0
+    SHA512 01fbff039bcec71d41334db2d07d0973b1ba58d30d05b29e35e1e3cee853917753b64e1101881113a33adb801559855d38d274fbb3383cfb24d85565254d112d
+    HEAD_REF main
+    PATCHES
+        disable_unit_tests_examples_and_tutorials.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DDART_VERBOSE=ON
+        -DDART_MSVC_DEFAULT_OPTIONS=ON
+        -DDART_SKIP_DOXYGEN=ON
+        -DDART_SKIP_FLANN=ON
+        -DDART_SKIP_IPOPT=ON
+        -DDART_SKIP_NLOPT=ON
+        -DDART_SKIP_OPENGL=ON
+        -DDART_SKIP_pagmo=ON
+        -Durdfdom_headers_VERSION_MAJOR=1
+        -Durdfdom_headers_VERSION_MINOR=0
+        -Durdfdom_headers_VERSION_PATCH=4
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH share/dart/cmake PACKAGE_NAME dart)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# only used for tests and examples (we removed the examples in share/doc above):
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dart/config.hpp" "#define DART_ROOT_PATH \"${SOURCE_PATH}/\"" "")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dart/config.hpp" "#define DART_DATA_PATH \"${SOURCE_PATH}/data/\"" "")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dart/config.hpp" "#define DART_DATA_LOCAL_PATH \"${SOURCE_PATH}/data/\"" "")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dart/config.hpp" "#define DART_DATA_GLOBAL_PATH \"${CURRENT_PACKAGES_DIR}/share/doc/dart/data/\"" "")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/dartsim/portfile.cmake
+++ b/dartsim/portfile.cmake
@@ -1,4 +1,3 @@
-# Shared library support is broken upstream (https://github.com/dartsim/dart/issues/1005#issuecomment-375406260)
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
@@ -9,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         disable_unit_tests_examples_and_tutorials.patch
+        fix_msvc2022_compilation.patch
 )
 
 vcpkg_cmake_configure(

--- a/dartsim/vcpkg.json
+++ b/dartsim/vcpkg.json
@@ -1,0 +1,34 @@
+{
+  "name": "dartsim",
+  "version": "6.11.0",
+  "port-version": 3,
+  "description": "Dynamic Animation and Robotics Toolkit",
+  "homepage": "https://dartsim.github.io/",
+  "dependencies": [
+    "assimp",
+    "boost-algorithm",
+    "boost-filesystem",
+    "boost-functional",
+    "boost-lexical-cast",
+    "boost-math",
+    "boost-optional",
+    "boost-regex",
+    "boost-system",
+    "bullet3",
+    "ccd",
+    "eigen3",
+    "fcl",
+    "octomap",
+    "ode",
+    "tinyxml2",
+    "urdfdom",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/dartsim/vcpkg.json
+++ b/dartsim/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "dartsim",
   "version": "6.11.0",
-  "port-version": 3,
-  "description": "Dynamic Animation and Robotics Toolkit",
+  "port-version": 4,
+  "description": "Dynamic Animation and Robotics Toolkit. OpenRobotics patched",
   "homepage": "https://dartsim.github.io/",
   "dependencies": [
     "assimp",


### PR DESCRIPTION
1. Imported DARTSim from the 2022-03-21 tag from vcpkg 8fe672b9fdbceb1c8771c05293cec8b64c1f2a8d
2. Added @mjcarroll patch to compile the version with msvc 8b636a67d186ebb1016ca77430cce01a2870bac6

Tested manually before using it in the buildfarm:
```
Building package dartsim[core]:x64-windows...
-- Installing port from location: C:/vcpkg/osrf_vcpkg_ports\dartsim
-- Note: dartsim only supports static library linkage. Building static library.
-- Downloading https://github.com/dartsim/dart/archive/v6.11.0.tar.gz -> dartsim-dart-v6.11.0.tar.gz...
-- Extracting source C:/vcpkg/downloads/dartsim-dart-v6.11.0.tar.gz
-- Applying patch disable_unit_tests_examples_and_tutorials.patch
-- Applying patch fix_msvc2022_compilation.patch
-- Using source at C:/vcpkg/buildtrees/dartsim/src/v6.11.0-c0a801b012.clean
-- Found external ninja('1.10.2').
-- Configuring x64-windows
-- Building x64-windows-rel
-- Installing: C:/vcpkg/packages/dartsim_x64-windows/share/dartsim/copyright
-- Performing post-build validation
-- Performing post-build validation done
Stored binary cache: C:\Users\Administrator\AppData\Local\vcpkg\archives\15\155323dbac9a44d09eb84d862adcfb963e33fc62334d6ce8754abeaff750150c.zip
Installing package dartsim[core]:x64-windows...
Elapsed time for package dartsim:x64-windows: 22.61 min

Total elapsed time: 23.73 min
```
